### PR TITLE
Adam's changes 5/12

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
-  "name": "CHANGE THIS : Extension boilerplate",
+  "name": "Google Forms Quality of Life Improvements",
   "version": "0.0.1",
   "manifest_version": 2,
-  "description": "This extension was created with the awesome extensionizr.com",
-  "homepage_url": "http://extensionizr.com",
+  "description": "This Lightbulb Education extension is designed to add various quality of life improvements to Google Forms, including an option to eliminate answer choices (handy for students taking tests).",
+  "homepage_url": "https://lightbulb.education",
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",

--- a/src/inject/inject.css
+++ b/src/inject/inject.css
@@ -46,6 +46,14 @@
     display: block
 }
 
+.freebirdFormviewerViewItemsCheckboxContainer:hover > .x-button {
+    display: block
+}
+
 .freebirdFormviewerViewItemsRadioOptionContainer {
+    display: flex;
+}
+
+.freebirdFormviewerViewItemsCheckboxContainer {
     display: flex;
 }

--- a/src/inject/inject.css
+++ b/src/inject/inject.css
@@ -7,7 +7,7 @@
     padding-left: 10px;
     margin-left: -10px;
     opacity: 0.5;
-
+    pointer-events: none;
 }
 
 .disabled-option > label {
@@ -34,6 +34,7 @@
     margin: .5rem;
     font-size: .6rem;
     outline: none;
+    pointer-events: auto;
 }
 
 .x-button:hover {
@@ -48,4 +49,3 @@
 .freebirdFormviewerViewItemsRadioOptionContainer {
     display: flex;
 }
-

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -43,13 +43,13 @@ chrome.extension.sendMessage({}, function (response) {
                         var parent = $(this).closest(".freebirdFormviewerViewItemsRadioOptionContainer")
 
                         if (parent.attr("data-disabled") == "true") {
-                            parent.unbind('click');
+                            // parent.unbind('click');
                             parent.removeClass("disabled-option")
                             parent.attr("data-disabled", "false")
                         } else {
-                            parent.bind('click', function () {
-                                return false;
-                            });
+                            // parent.bind('click', function () {
+                            //     return false;
+                            // });
 
                             parent.addClass("disabled-option")
                             parent.attr("data-disabled", "true")

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -27,6 +27,7 @@ chrome.extension.sendMessage({}, function (response) {
             function handler() {
                 console.log('jquery added :)');
                 $(document).ready(function () {
+                    //configuration for radio choices
                     $(".freebirdFormviewerViewItemsRadioChoicesContainer").each(function () {
 
                         $(this).find(".freebirdFormviewerViewItemsRadioOptionContainer").each(function () {
@@ -37,10 +38,21 @@ chrome.extension.sendMessage({}, function (response) {
 
                     })
 
+                    //configuration for checkboxes
+                    $(".freebirdFormviewerViewItemsCheckboxOptionContainer").each(function () {
+
+                        $(this).find(".freebirdFormviewerViewItemsCheckboxChoice").each(function () {
+
+                            $(this).append("<button class='x-button'>✖</button>").addClass("relative-position")
+
+                        })
+
+                    })
+
                     $(".x-button").click(disableOption)
 
                     function disableOption() {
-                        var parent = $(this).closest(".freebirdFormviewerViewItemsRadioOptionContainer")
+                        var parent = $(this).parent()
 
                         if (parent.attr("data-disabled") == "true") {
                             // parent.unbind('click');


### PR DESCRIPTION
Made two separate commits. The first one adds pointer-events css to prevent clicking of the options after pressing "x". I've commented the code that binds the click function thing.

The second one I tried setting it up for checkboxes and coming up with a general solution that works for both of them. This seems to be creating more problems than it solves... maybe we should just have two separate functions for checkboxes and radio buttons? (i.e. two different disableOption()'s and two different css classes) Feel free to not commit that one if you think the two things is a better option.

Much love,
Adam